### PR TITLE
Fix: Electron app startup error with path module import

### DIFF
--- a/src/main/main.js
+++ b/src/main/main.js
@@ -1,5 +1,9 @@
 import { app, BrowserWindow } from 'electron';
-import path from 'path';
+// Bug fix for issue #9: Use namespace import for CommonJS interop
+// When TypeScript compiles ES module imports to CommonJS, 'import path from "path"'
+// becomes 'path_1.default.join()' which fails because Node.js built-in modules
+// don't have a default export. Using 'import * as path' correctly generates 'path_1.join()'.
+import * as path from 'path';
 var mainWindow = null;
 function createWindow() {
     mainWindow = new BrowserWindow({

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1,5 +1,9 @@
 import { app, BrowserWindow } from 'electron';
-import path from 'path';
+// Bug fix for issue #9: Use namespace import for CommonJS interop
+// When TypeScript compiles ES module imports to CommonJS, 'import path from "path"'
+// becomes 'path_1.default.join()' which fails because Node.js built-in modules
+// don't have a default export. Using 'import * as path' correctly generates 'path_1.join()'.
+import * as path from 'path';
 
 let mainWindow: BrowserWindow | null = null;
 


### PR DESCRIPTION
## Summary
- Fixes Electron app startup error caused by incorrect TypeScript/CommonJS interop for the `path` module
- Changed `import path from 'path'` to `import * as path from 'path'` in main.ts
- Added explanatory comment documenting the bug and solution

## Problem
The Electron app crashed on startup with an error related to `path_1.default.join()` not being a function. This occurred because:
1. TypeScript compiled `import path from 'path'` to `path_1.default.join()` 
2. Node.js built-in modules don't have a default export
3. The web version at http://localhost:5173/ worked fine since it doesn't use this code path

## Solution
Using namespace import (`import * as path from 'path'`) generates the correct CommonJS output (`path_1.join()`) that properly accesses the Node.js built-in module.

## Test Plan
- [x] All tests pass (81 tests)
- [x] Verified compiled JavaScript output uses correct `path.join()` syntax
- [x] No linting errors

Fixes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)